### PR TITLE
WIP: fix assorted workflow issues

### DIFF
--- a/src/isaw/policy/profile.zcml
+++ b/src/isaw/policy/profile.zcml
@@ -212,4 +212,14 @@
       import_steps="rolemap workflow placeful_workflow"
       />
 
+  <genericsetup:upgradeDepends
+      sortkey="10"
+      source="21"
+      destination="22"
+      title="Fix workflow issues"
+      description="fixes image and file upload, "
+      profile="isaw.policy:default"
+      import_steps="workflow"
+      />
+
 </configure>

--- a/src/isaw/policy/profiles/default/metadata.xml
+++ b/src/isaw/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>21</version>
+  <version>22</version>
   <dependencies>
     <dependency>profile-isaw.theme:default</dependency>
     <dependency>profile-isaw.facultycv:default</dependency>

--- a/src/isaw/policy/profiles/default/workflows.xml
+++ b/src/isaw/policy/profiles/default/workflows.xml
@@ -27,8 +27,12 @@
 <type type_id="Event">
 <bound-workflow workflow_id="isaw_reviewer_workflow"/>
 </type>
-<type type_id="File"/>
-<type type_id="Image"/>
+<type type_id="File">
+ <bound-workflow workflow_id="one_state_workflow"/>
+</type>
+<type type_id="Image">
+ <bound-workflow workflow_id="one_state_workflow"/>
+</type>
 <type type_id="News Item">
 <bound-workflow workflow_id="isaw_reviewer_workflow"/>
 </type>

--- a/src/isaw/policy/profiles/default/workflows/isaw_intranet_workflow/definition.xml
+++ b/src/isaw/policy/profiles/default/workflows/isaw_intranet_workflow/definition.xml
@@ -3,6 +3,7 @@
  <permission>Access contents information</permission>
  <permission>Change portal events</permission>
  <permission>Modify portal content</permission>
+ <permission>Delete objects</permission>
  <permission>View</permission>
  <state state_id="draft" title="">
   <exit-transition transition_id="submit"/>
@@ -26,6 +27,12 @@
    <permission-role>Owner</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
   <permission-map name="View" acquired="False">
    <permission-role>Reviewer</permission-role>
    <permission-role>Editor</permission-role>
@@ -46,6 +53,10 @@
    <permission-role>Site Administrator</permission-role>
   </permission-map>
   <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
    <permission-role>Manager</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>
@@ -76,6 +87,10 @@
    <permission-role>Manager</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
   <permission-map name="View" acquired="False">
    <permission-role>Reviewer</permission-role>
    <permission-role>Editor</permission-role>
@@ -96,6 +111,10 @@
    <permission-role>Site Administrator</permission-role>
   </permission-map>
   <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
    <permission-role>Manager</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>

--- a/src/isaw/policy/profiles/default/workflows/isaw_intranet_workflow/definition.xml
+++ b/src/isaw/policy/profiles/default/workflows/isaw_intranet_workflow/definition.xml
@@ -39,11 +39,7 @@
   <description>Reviewer publishes content internally</description>
   <exit-transition transition_id="reject"/>
   <permission-map name="Access contents information" acquired="False">
-   <permission-role>Reviewer</permission-role>
-   <permission-role>Editor</permission-role>
-   <permission-role>Reader</permission-role>
-   <permission-role>Manager</permission-role>
-   <permission-role>Site Administrator</permission-role>
+   <permission-role>Authenticated</permission-role>
   </permission-map>
   <permission-map name="Change portal events" acquired="False">
    <permission-role>Manager</permission-role>
@@ -54,11 +50,7 @@
    <permission-role>Site Administrator</permission-role>
   </permission-map>
   <permission-map name="View" acquired="False">
-   <permission-role>Reviewer</permission-role>
-   <permission-role>Editor</permission-role>
-   <permission-role>Reader</permission-role>
-   <permission-role>Manager</permission-role>
-   <permission-role>Site Administrator</permission-role>
+   <permission-role>Authenticated</permission-role>
   </permission-map>
  </state>
  <state state_id="pending" title="Pending review">

--- a/src/isaw/policy/profiles/default/workflows/isaw_intranet_workflow/definition.xml
+++ b/src/isaw/policy/profiles/default/workflows/isaw_intranet_workflow/definition.xml
@@ -73,7 +73,6 @@
    <permission-role>Site Administrator</permission-role>
   </permission-map>
   <permission-map name="Modify portal content" acquired="False">
-   <permission-role>Editor</permission-role>
    <permission-role>Manager</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>

--- a/src/isaw/policy/profiles/default/workflows/isaw_standard_workflow/definition.xml
+++ b/src/isaw/policy/profiles/default/workflows/isaw_standard_workflow/definition.xml
@@ -3,6 +3,7 @@
  <permission>Access contents information</permission>
  <permission>Change portal events</permission>
  <permission>Modify portal content</permission>
+ <permission>Delete objects</permission>
  <permission>View</permission>
  <state state_id="draft" title="">
   <exit-transition transition_id="submit"/>
@@ -20,6 +21,12 @@
    <permission-role>Site Administrator</permission-role>
   </permission-map>
   <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
    <permission-role>Manager</permission-role>
    <permission-role>Owner</permission-role>
    <permission-role>Editor</permission-role>
@@ -55,6 +62,10 @@
    <permission-role>Manager</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
   <permission-map name="View" acquired="False">
    <permission-role>Reviewer</permission-role>
    <permission-role>Reader</permission-role>
@@ -75,6 +86,10 @@
    <permission-role>Site Administrator</permission-role>
   </permission-map>
   <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
    <permission-role>Manager</permission-role>
    <permission-role>Site Administrator</permission-role>
   </permission-map>


### PR DESCRIPTION
This WIP pr addresses workflow issues identified in the following tickets:
- isawnyu/isaw.web#63
- isawnyu/isaw.web#103
- isawnyu/isaw.web#104
- isawnyu/isaw.web#105

remaining issue is the problem with folks being able to check in working copies to baseline objects in the `pending` or `published` states.
